### PR TITLE
Export cleaned missions.

### DIFF
--- a/apps/transcripts/management/commands/export.py
+++ b/apps/transcripts/management/commands/export.py
@@ -1,0 +1,72 @@
+import errno
+import json
+import os
+
+from django.core.management.base import BaseCommand, CommandError
+from django.core.exceptions import ObjectDoesNotExist
+
+from apps.transcripts.models import Mission
+
+class Command(BaseCommand):
+    help = """Export a cleaned transcript and basic metadata file for use in
+Spacelog.
+
+If a transcript name isn't passed, the default is TEC."""
+
+    args = "<mission-short-name> <export-dir> [<transcript-name>]"
+
+    def handle(self, *args, **kwargs):
+        if len(args) < 2 or len(args) > 3:
+            raise CommandError("Wrong number of arguments.")
+
+        try:
+            mission = Mission.objects.get(short_name=args[0])
+        except ObjectDoesNotExist:
+            raise CommandError("No such mission.")
+
+        export_dir = args[1]
+        self._mkdir(os.path.join(export_dir, "transcripts"))
+
+        main_transcript = "TEC"
+        if len(args) > 2:
+            main_transcript = args[2]
+
+        cleaners = set()
+        with open(os.path.join(export_dir, "transcripts", main_transcript), "w") as f:
+            for page in mission.pages.all():
+                f.write("\tPage %d\n" % page.number)
+                f.write("\tApproved? %s\n" % page.approved)
+                f.write(page.text)
+                f.write("\n")
+
+                for revision in page.revisions.all():
+                    cleaners.add(revision.by.name)
+
+        cleaners = list(cleaners)
+        cleaners.sort()
+        upper_title, lower_title = mission.name.split(" ", 1)
+        meta = {
+            "name": mission.short_name.lower(),
+            "incomplete": True,
+            "subdomains": [mission.short_name.lower()],
+            "copy": {
+                "title": mission.name,
+                "upper_title": upper_title,
+                "lower_title": lower_title,
+                "cleaners": cleaners,
+            },
+            "main_transcript": "%s/%s" % (mission.short_name.lower(), main_transcript),
+            "utc_launch_time": mission.start.isoformat(),
+        }
+        with open(os.path.join(export_dir, "transcripts", "_meta"), "w") as f:
+            f.write(json.dumps(meta, indent=4))
+            f.write("\n")
+
+    def _mkdir(self, path):
+        try:
+            os.makedirs(path)
+        except OSError as err:
+            if err.errno == errno.EEXIST and os.path.isdir(path):
+                pass
+            else:
+                raise CommandError("Cannot create directory '%s'" % path)

--- a/kallisto/urls.py
+++ b/kallisto/urls.py
@@ -10,6 +10,7 @@ urlpatterns = patterns(
     url(r'^admin/', include(admin.site.urls)),
     url(r'^(?P<slug>[0-9A-Za-z]+)/$', 'apps.transcripts.views.clean', name='mission-clean-next'),
     url(r'^(?P<slug>[0-9A-Za-z]+)/(?P<page>[0-9]+)/$', 'apps.transcripts.views.page', name='mission-page'),
+    url(r'^(?P<slug>[0-9A-Za-z]+)/export/$', 'apps.transcripts.views.export', name='mission-export'),
 
     url(r'^account/register/$', 'apps.people.views.register', name='register'),
     url(r'^account/registered/$', 'apps.people.views.registered', name='registered'),


### PR DESCRIPTION
Provides two ways to export mission transcripts:

* A management command, e.g. `python manage.py export MA8 ../spacelog/missions/ma8`
* A URL, e.g. http://kallisto.spacelog.org/MA8/export/

Exports:

* The mission transcript as a single file, ready for additional checks and conversion to the Spacelog format.
* A basic _meta transcript, with most of the information Kallisto has about the mission, including the list of people who cleaned the transcript.