### PR TITLE
Use programming font when cleaning for better readability.

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -313,7 +313,7 @@ html.js-ready header ul.anon.user-options li:hover {
     padding: 33px 0;
 }
 .clean.page #clean textarea {
-    font-family: monospace;
+    font-family: 'Inconsolata', monospace;
     line-height: 175%;
 }
 .clean.page form button {

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,7 @@
 
 {% block head-css-stylesheet %}
 <link rel='stylesheet' type='text/css' href='{% static "css/base.css" %}'>
+<link href='https://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
 {% endblock %}
 
 {% block body-sheath %}


### PR DESCRIPTION
This commit uses Google's "Inconsolata" web font which is intended for
use in programming. It has more distinctive `O`s, `0`s, `1`s, and `l`s, ("oh",
"zero", "one", "lower-case L").

This also retains the 'monospace' font-family in case the user is unable
to use the Inconsolata font.